### PR TITLE
Fix calls to deprecated boolean attribute

### DIFF
--- a/database/factories/AddressFactory.php
+++ b/database/factories/AddressFactory.php
@@ -23,7 +23,7 @@ class AddressFactory extends Factory
                 'Head Office',
                 'Mums House',
             ]),
-            'billing' => $this->faker->boolean,
+            'billing' => $this->faker->boolean(),
             'user_id' => User::factory()->create(),
             'location_id' => Location::factory()->create(),
         ];

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -22,10 +22,10 @@ class ProductFactory extends Factory
             'description' => $this->faker->paragraphs(2, true),
             'cost' => $cost,
             'retail' => ($cost * config('shop.profit_margin')),
-            'active' => $this->faker->boolean,
+            'active' => $this->faker->boolean(),
             'vat' => config('shop.vat'),
             'category_id' => Category::factory()->create(),
-            'range_id' => $this->faker->boolean ? Range::factory()->create() : null,
+            'range_id' => $this->faker->boolean() ? Range::factory()->create() : null,
         ];
     }
 }

--- a/database/factories/VariantFactory.php
+++ b/database/factories/VariantFactory.php
@@ -15,8 +15,8 @@ class VariantFactory extends Factory
     public function definition(): array
     {
         $product = Product::factory()->create();
-        $cost = $this->faker->boolean ? $product->cost : ($product->cost + $this->faker->numberBetween(100, 7500));
-        $shippable = $this->faker->boolean;
+        $cost = $this->faker->boolean() ? $product->cost : ($product->cost + $this->faker->numberBetween(100, 7500));
+        $shippable = $this->faker->boolean();
 
         return [
             'name' => $this->faker->words(3, true),
@@ -26,7 +26,7 @@ class VariantFactory extends Factory
             'width' => $shippable ? $this->faker->numberBetween(100, 10000) : null,
             'length' => $shippable ? $this->faker->numberBetween(100, 10000) : null,
             'weight' => $shippable ? $this->faker->numberBetween(100, 10000) : null,
-            'active' => $this->faker->boolean,
+            'active' => $this->faker->boolean(),
             'shippable' => $shippable,
             'product_id' => $product->id,
         ];


### PR DESCRIPTION
Calling `$this->faker->boolean` results in the following warning: 

```
PHP Deprecated:  Since fakerphp/faker 1.14: Accessing property "boolean" is deprecated, use "boolean()" instead.
``` 
This commit fixes that. 