### PR TITLE
Datasets and Test Action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,71 @@
+name: Laravel tests using Mysql
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - features/**
+
+jobs:
+  laravel-tests:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE:  test_laravel
+          MYSQL_USER: ci_user
+          MYSQL_PASSWORD: secret
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: [ '8.0' ]
+        dependency-stability: [ prefer-stable ]
+
+    name: P${{ matrix.php-versions }} - L${{ matrix.laravel }} - ${{ matrix.dependency-stability }} - ${{ matrix.operating-system}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install PHP versions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory 2
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        id: actions-cache
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Cache PHP dependencies
+        uses: actions/cache@v2
+        id: vendor-cache
+        with:
+          path: vendor
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/composer.lock') }}
+      - name: Install Dependencies
+        if: steps.vendor-cache.outputs.cache-hit != 'true'
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Execute tests (Unit and Feature tests) via PestPHP
+        env:
+          DB_CONNECTION: mysql
+          DB_DATABASE: test_laravel
+          DB_PORT: 3306
+          DB_USER: ci_user
+          DB_PASSWORD: secret
+
+        run: vendor/bin/pest

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </coverage>
     <php>
         <server name="APP_ENV" value="testing"/>
+        <server name="APP_KEY" value="base64:XLSh8/5MStcbEgKkbp8bPz8R8DK1X/ss3fSvVU3lGgE="/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
          <server name="DB_CONNECTION" value="sqlite"/>

--- a/tests/Datasets/Carts.php
+++ b/tests/Datasets/Carts.php
@@ -1,0 +1,16 @@
+<?php
+
+use Domains\Customer\Models\Cart;
+use Domains\Customer\Models\CartItem;
+
+dataset('cart',[
+    fn() => Cart::factory()->create()
+]);
+
+dataset('3CartItems',[
+    fn() => CartItem::factory()->create(['quantity' => 3])
+]);
+
+dataset('cartItem',[
+    fn() => CartItem::factory()->create(['quantity' => 1])
+]);

--- a/tests/Datasets/Coupons.php
+++ b/tests/Datasets/Coupons.php
@@ -1,0 +1,7 @@
+<?php
+
+use Domains\Customer\Models\Coupon;
+
+dataset('coupon', [
+    fn() => Coupon::factory()->create()
+]);

--- a/tests/Datasets/Products.php
+++ b/tests/Datasets/Products.php
@@ -1,0 +1,7 @@
+<?php
+
+use Domains\Catalog\Models\Variant;
+
+dataset('variant', [
+    fn() => Variant::factory()->create()
+]);


### PR DESCRIPTION
Extracts cart, product and coupon datasets for the fun of it. 

If merged (feel free to decline), this PR will also add a `laravel-test` Github action to run tests on `main`, `develop` and `feature/**` branches.

Thanks Steve for an amazing stream as always